### PR TITLE
[GFD-118] Enable Codecov carryforward for monorepo coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+# GFD-118: Touch ci.yml to trigger full CI run and establish Codecov baseline
 name: CI
 permissions:
   contents: write

--- a/codecov.yml
+++ b/codecov.yml
@@ -39,23 +39,30 @@ component_management:
 
 flags:
   unit-storybook:
+    carryforward: true
     paths:
       - twinkletaps-app/src/
   integration:
+    carryforward: true
     paths:
       - twinkletaps-app/src/
   hivemq-auth-extension:
+    carryforward: true
     paths:
       - hivemq-auth-extension/src/main/
   agent-utils:
+    carryforward: true
     paths:
       - agent-utils/agent_utils/
   cursor-retro:
+    carryforward: true
     paths:
       - cursor-retro/cursor_retro/
   jira-utils:
+    carryforward: true
     paths:
       - jira-utils/jira_utils/
   ticket-loop:
+    carryforward: true
     paths:
       - ticket-loop/ticket_loop/


### PR DESCRIPTION
## Summary

- Add `carryforward: true` to all 7 flag definitions in `codecov.yml`
- Touch `ci.yml` to trigger full CI run on merge, establishing baseline coverage for all flags

## What this fixes

Codecov currently shows coverage for only the package touched in a PR. Without `carryforward`, flags for untouched packages have no data for the commit, so coverage reports are incomplete. With `carryforward: true`, Codecov reuses the most recent coverage data from prior commits for flags that were not uploaded.

## How to test

1. After merging, create a PR that touches only one package
2. Confirm the Codecov PR comment includes all 7 flags/components
3. Confirm the Codecov dashboard shows carried-forward coverage for untouched packages

## Notes

- Config-only change — no application code modified
- The first PR after merge may need a full CI run on main to establish baseline data (handled by the ci.yml touch)
- 2 MQTT integration tests fail on main due to no local MQTT broker — pre-existing, unrelated