### PR TITLE
[GFD-122] Fix chromatic highlights issue with profile icon

### DIFF
--- a/twinkletaps-app/src/components/app/Navbar/NavbarView.tsx
+++ b/twinkletaps-app/src/components/app/Navbar/NavbarView.tsx
@@ -104,7 +104,7 @@ export function NavbarView({
               <Button
                 variant="ghost"
                 size="sm"
-                className="flex items-center gap-2"
+                className="chromatic-ignore flex items-center gap-2"
               >
                 {profile.avatar ? (
                   <Image


### PR DESCRIPTION
## Summary

- Adds `chromatic-ignore` class to the profile dropdown trigger Button in `NavbarView.tsx`
- Prevents Chromatic from flagging false-positive diffs caused by varying e2e test email text width shifting the User icon position

## Jira

GFD-122

## How to test

- `npm run test` — all unit/storybook tests pass (140/140)
- `npm run lint` — clean
- The real validation is the next Chromatic build no longer flagging the profile icon area