### PR TITLE
[GFD-90] Enable previously-skipped mobile e2e tests with screenshot capture

### DIFF
--- a/twinkletaps-app/tests/device-invite.spec.ts
+++ b/twinkletaps-app/tests/device-invite.spec.ts
@@ -52,6 +52,18 @@ test("device invite: admin shares device, member accepts", async ({
 
   await page.getByRole("button", { name: "Done" }).click();
 
+  // On mobile, the sidebar Sheet stays open after the dialog closes — dismiss it
+  if (isMobile) {
+    await expect(
+      page.locator("[data-slot='dialog-content']"),
+    ).toBeHidden({ timeout: 5000 });
+    const vp = page.viewportSize()!;
+    await page.mouse.click(vp.width - 20, vp.height / 2);
+    await expect(
+      page.locator("[data-slot='sheet-overlay']"),
+    ).toBeHidden({ timeout: 5000 });
+  }
+
   // ── Admin: navigate to the device ────────────────────────────────
   // router.refresh() in onSuccess causes the page to reload with the new device
   // Click the device card in the main content area (has role="button")

--- a/twinkletaps-app/tests/device-invite.spec.ts
+++ b/twinkletaps-app/tests/device-invite.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect, takeSnapshot } from "@chromatic-com/playwright";
-import { login, captureScreen } from "../src/test-utils/playwright";
+import {
+  login,
+  captureScreen,
+  openSidebarIfMobile,
+} from "../src/test-utils/playwright";
 
 test.describe.configure({ retries: 2 });
 
@@ -8,9 +12,6 @@ test("device invite: admin shares device, member accepts", async ({
   browser,
   isMobile,
 }) => {
-  // The sidebar footer is a Sheet on mobile and has no trigger in the current UI
-  test.skip(isMobile, "Sidebar is inaccessible on mobile — SidebarTrigger not present");
-
   const runId = crypto.randomUUID();
   const adminEmail = `testadmin-${runId}@test.com`;
   const memberEmail = `testmember-${runId}@test.com`;
@@ -23,10 +24,18 @@ test("device invite: admin shares device, member accepts", async ({
   // After login, user is redirected to /w/<workspaceId>
   await expect(page).toHaveURL(/\/w\/[^/]+$/, { timeout: 15000 });
 
+  await captureScreen(page, "admin-after-login");
+  await takeSnapshot(page, "admin-after-login", test.info());
+
   // ── Admin: register a device via sidebar ─────────────────────────
+  await openSidebarIfMobile(page, isMobile);
   await expect(
     page.getByRole("button", { name: "Register Device" }),
   ).toBeVisible({ timeout: 10000 });
+
+  await captureScreen(page, "sidebar-open");
+  await takeSnapshot(page, "sidebar-open", test.info());
+
   await page.getByRole("button", { name: "Register Device" }).click();
 
   // RegisterDeviceDialog — fill name, submit
@@ -85,6 +94,9 @@ test("device invite: admin shares device, member accepts", async ({
 
   // After login, member is redirected to /w/<workspaceId>
   await expect(memberPage).toHaveURL(/\/w\/[^/]+$/, { timeout: 15000 });
+
+  await captureScreen(memberPage, "member-after-login");
+  await takeSnapshot(memberPage, "member-after-login", test.info());
 
   // ── Member: navigate to invite URL and accept ─────────────────────
   // Use "load" not "networkidle" — Next.js keeps connections open and

--- a/twinkletaps-app/tests/device-invite.spec.ts
+++ b/twinkletaps-app/tests/device-invite.spec.ts
@@ -64,6 +64,9 @@ test("device invite: admin shares device, member accepts", async ({
     ).toBeHidden({ timeout: 5000 });
   }
 
+  await captureScreen(page, "main-content-after-register");
+  await takeSnapshot(page, "main-content-after-register", test.info());
+
   // ── Admin: navigate to the device ────────────────────────────────
   // router.refresh() in onSuccess causes the page to reload with the new device
   // Click the device card in the main content area (has role="button")

--- a/twinkletaps-app/tests/invite.spec.ts
+++ b/twinkletaps-app/tests/invite.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect, takeSnapshot } from "@chromatic-com/playwright";
-import { login, captureScreen } from "../src/test-utils/playwright";
+import {
+  login,
+  captureScreen,
+  openSidebarIfMobile,
+} from "../src/test-utils/playwright";
 
 test.describe.configure({ retries: 2 });
 
@@ -8,9 +12,6 @@ test("workspace invite: user A creates link, user B accepts", async ({
   browser,
   isMobile,
 }) => {
-  // The sidebar footer is a Sheet on mobile and has no trigger in the current UI
-  test.skip(isMobile, "Sidebar is inaccessible on mobile — SidebarTrigger not present");
-
   const runId = crypto.randomUUID();
   const adminEmail = `testadmin-${runId}@test.com`;
   const memberEmail = `testmember-${runId}@test.com`;
@@ -22,16 +23,24 @@ test("workspace invite: user A creates link, user B accepts", async ({
   // After login, user is redirected to /w/<workspaceId>
   await expect(page).toHaveURL(/\/w\/[^/]+$/, { timeout: 15000 });
 
-  await captureScreen(page, "admin-workspace");
-  await takeSnapshot(page, "admin-workspace", test.info());
+  await captureScreen(page, "admin-after-login");
+  await takeSnapshot(page, "admin-after-login", test.info());
 
   // ── User A: open "Invite to workspace" from sidebar ───────────────
+  await openSidebarIfMobile(page, isMobile);
   await expect(
     page.getByRole("button", { name: "Invite to workspace" }),
   ).toBeVisible({ timeout: 10000 });
+
+  await captureScreen(page, "sidebar-open");
+  await takeSnapshot(page, "sidebar-open", test.info());
+
   await page.getByRole("button", { name: "Invite to workspace" }).click();
 
   // ShareDialog opens — click "Generate link"
+  await captureScreen(page, "invite-dialog");
+  await takeSnapshot(page, "invite-dialog", test.info());
+
   await page.getByRole("button", { name: "Generate link" }).click();
 
   // Read the invite URL from the <code> element scoped to the dialog
@@ -56,6 +65,9 @@ test("workspace invite: user A creates link, user B accepts", async ({
   await login(memberPage, memberEmail);
   // After login, member is redirected to /w/<workspaceId>
   await expect(memberPage).toHaveURL(/\/w\/[^/]+$/, { timeout: 15000 });
+
+  await captureScreen(memberPage, "member-after-login");
+  await takeSnapshot(memberPage, "member-after-login", test.info());
 
   // ── User B: navigate to invite URL and accept ─────────────────────
   // Use "load" not "networkidle" — Next.js keeps connections open and


### PR DESCRIPTION
## Summary

- Remove `test.skip(isMobile, ...)` guards from `invite.spec.ts` and `device-invite.spec.ts`
- Add `openSidebarIfMobile(page, isMobile)` calls before sidebar interactions in both tests
- Add `captureScreen` + `takeSnapshot` calls at key UI states (after login, sidebar open, dialog states, member flows)
- Add mobile-specific sidebar Sheet dismissal in `device-invite.spec.ts` after dialog close (wait for dialog hidden, click overlay, wait for sheet hidden)

## Test plan

- [x] `npm run lint` — passes
- [x] `npm run test` — 140 unit/storybook tests pass
- [x] `npm run test:e2e` — 57/57 pass (8 pre-existing skips), including Mobile Chrome + Mobile Safari for both invite and device-invite tests
- [x] Screenshots captured in `test-results/screenshots/` with correct mobile viewport labels
- [x] Mobile Chrome device-invite: 3/3 repeat runs pass (no flakiness)
- [x] Mobile Safari device-invite: 3/3 repeat runs pass (no flakiness)

## Note

Review identified a pre-existing issue: member browser contexts created via `browser.newContext()` do not inherit the mobile viewport from the test project. This means member-page screenshots are at desktop resolution even in mobile test runs. This predates this PR and should be addressed as a follow-up task.