### PR TITLE
[GFD-102] Fix ctrl-c not killing claude-code in ticket-loop

### DIFF
--- a/ticket-loop/tests/test_ticket_loop.py
+++ b/ticket-loop/tests/test_ticket_loop.py
@@ -234,7 +234,7 @@ def test_resume_session_calls_claude(tmp_path, monkeypatch):
 
     save_session("GFD-42", "resume-sid", Phase.IMPLEMENTATION)
 
-    with patch("ticket_loop.main.subprocess.run") as mock_run:
+    with patch("ticket_loop.main._run_in_process_group") as mock_run:
         resume_session("GFD-42")
 
     cmd = mock_run.call_args.args[0]
@@ -270,7 +270,7 @@ def test_swap_session_to_resume():
 
 def test_run_with_session_retry_succeeds_first_try():
     """No retry when the first subprocess call succeeds."""
-    with patch("ticket_loop.main.subprocess.run") as mock_run:
+    with patch("ticket_loop.main._run_in_process_group") as mock_run:
         _run_with_session_retry(["claude", "--session-id", "new-sid"])
 
     assert mock_run.call_count == 1
@@ -281,7 +281,7 @@ def test_run_with_session_retry_retries_on_conflict():
     conflict = subprocess.CalledProcessError(
         1, "claude", stderr="Session ID abc is already in use."
     )
-    with patch("ticket_loop.main.subprocess.run") as mock_run:
+    with patch("ticket_loop.main._run_in_process_group") as mock_run:
         mock_run.side_effect = [conflict, None]
         _run_with_session_retry(["claude", "--session-id", "abc"])
 
@@ -296,7 +296,7 @@ def test_run_with_session_retry_propagates_other_errors():
     other_error = subprocess.CalledProcessError(
         1, "claude", stderr="Something else went wrong"
     )
-    with patch("ticket_loop.main.subprocess.run", side_effect=other_error):
+    with patch("ticket_loop.main._run_in_process_group", side_effect=other_error):
         with pytest.raises(subprocess.CalledProcessError):
             _run_with_session_retry(["claude", "--session-id", "abc"])
 
@@ -735,7 +735,7 @@ def test_resume_session_prefers_implementation(tmp_path, monkeypatch):
     save_session("GFD-42", "plan-sid", Phase.PLANNING)
     save_session("GFD-42", "impl-sid", Phase.IMPLEMENTATION)
 
-    with patch("ticket_loop.main.subprocess.run") as mock_run:
+    with patch("ticket_loop.main._run_in_process_group") as mock_run:
         resume_session("GFD-42")
 
     cmd = mock_run.call_args.args[0]
@@ -749,7 +749,7 @@ def test_resume_session_falls_back_to_planning(tmp_path, monkeypatch):
 
     save_session("GFD-42", "plan-sid", Phase.PLANNING)
 
-    with patch("ticket_loop.main.subprocess.run") as mock_run:
+    with patch("ticket_loop.main._run_in_process_group") as mock_run:
         resume_session("GFD-42")
 
     cmd = mock_run.call_args.args[0]
@@ -766,7 +766,7 @@ def test_resume_session_falls_back_to_legacy(tmp_path, monkeypatch):
     with open(sessions_file, "a") as f:
         f.write(json.dumps(record) + "\n")
 
-    with patch("ticket_loop.main.subprocess.run") as mock_run:
+    with patch("ticket_loop.main._run_in_process_group") as mock_run:
         resume_session("GFD-42")
 
     cmd = mock_run.call_args.args[0]

--- a/ticket-loop/tests/test_ticket_loop.py
+++ b/ticket-loop/tests/test_ticket_loop.py
@@ -1,6 +1,7 @@
 """Lightweight tests for ticket_loop — pure logic and basic I/O only."""
 
 import json
+import signal
 import subprocess
 from unittest.mock import MagicMock, patch
 
@@ -10,6 +11,7 @@ from ticket_loop.main import (
     COLUMN_HANDLERS,
     Phase,
     _run_continuous,
+    _run_in_process_group,
     _run_loop,
     _run_with_session_retry,
     _swap_session_to_resume,
@@ -920,3 +922,258 @@ def test_handle_in_progress_looks_up_implementation_phase(tmp_path, monkeypatch)
         handle_in_progress(task)
 
     assert mock_claude.call_args.kwargs["session_id"] == "impl-sid"
+
+
+# -- _run_in_process_group --
+
+
+def _mock_proc(*, returncode=0, stdout=None, stderr=None):
+    """Create a mock Popen process for _run_in_process_group tests."""
+    proc = MagicMock()
+    proc.pid = 12345
+    proc.returncode = returncode
+    proc.communicate.return_value = (stdout, stderr)
+    proc.args = ["claude", "-p"]
+    return proc
+
+
+def _signal_tracker():
+    """Build a fake signal.signal that tracks installed handlers."""
+    installed = {}
+
+    def fake_signal(signum, handler):
+        old = installed.get(signum, signal.SIG_DFL)
+        installed[signum] = handler
+        return old
+
+    return fake_signal, installed
+
+
+class TestRunInProcessGroup:
+    """Tests for _run_in_process_group signal-safe subprocess runner."""
+
+    def test_returns_completed_process_on_success(self):
+        """Child exits 0, returns CompletedProcess with correct returncode."""
+        proc = _mock_proc(returncode=0)
+        with patch("ticket_loop.main.subprocess.Popen", return_value=proc):
+            result = _run_in_process_group(["claude", "-p"])
+
+        assert isinstance(result, subprocess.CompletedProcess)
+        assert result.returncode == 0
+
+    def test_check_raises_on_nonzero_exit(self):
+        """Non-zero exit with check=True raises CalledProcessError."""
+        proc = _mock_proc(returncode=1, stderr="some error")
+        with patch("ticket_loop.main.subprocess.Popen", return_value=proc):
+            with pytest.raises(subprocess.CalledProcessError) as exc_info:
+                _run_in_process_group(["claude", "-p"], check=True)
+
+        assert exc_info.value.returncode == 1
+        assert exc_info.value.stderr == "some error"
+
+    def test_nonzero_exit_without_check_returns_normally(self):
+        """Non-zero exit with check=False returns CompletedProcess."""
+        proc = _mock_proc(returncode=1)
+        with patch("ticket_loop.main.subprocess.Popen", return_value=proc):
+            result = _run_in_process_group(["claude", "-p"], check=False)
+
+        assert result.returncode == 1
+
+    def test_passes_kwargs_to_popen(self):
+        """Extra kwargs (cwd, stderr, text) are forwarded to Popen."""
+        proc = _mock_proc()
+        with patch(
+            "ticket_loop.main.subprocess.Popen", return_value=proc
+        ) as mock_popen:
+            _run_in_process_group(
+                ["claude", "-p"], cwd="/workspace", stderr=subprocess.PIPE, text=True
+            )
+
+        mock_popen.assert_called_once_with(
+            ["claude", "-p"],
+            start_new_session=True,
+            cwd="/workspace",
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+    def test_popen_uses_start_new_session(self):
+        """Popen is called with start_new_session=True."""
+        proc = _mock_proc()
+        with patch(
+            "ticket_loop.main.subprocess.Popen", return_value=proc
+        ) as mock_popen:
+            _run_in_process_group(["claude", "-p"])
+
+        assert mock_popen.call_args.kwargs["start_new_session"] is True
+
+    def test_sigint_forwards_sigterm_to_child_group(self):
+        """SIGINT sends SIGTERM to child process group via os.killpg."""
+        proc = _mock_proc(returncode=-signal.SIGTERM)
+        fake_signal, installed = _signal_tracker()
+
+        def fake_communicate():
+            handler = installed.get(signal.SIGINT)
+            if callable(handler):
+                handler(signal.SIGINT, None)
+            return (None, None)
+
+        proc.communicate.side_effect = fake_communicate
+
+        with (
+            patch("ticket_loop.main.subprocess.Popen", return_value=proc),
+            patch("ticket_loop.main.signal.signal", side_effect=fake_signal),
+            patch("ticket_loop.main.os.killpg") as mock_killpg,
+            patch("ticket_loop.main.os.getpgid", return_value=12345),
+        ):
+            with pytest.raises(KeyboardInterrupt):
+                _run_in_process_group(["claude", "-p"])
+
+        mock_killpg.assert_any_call(12345, signal.SIGTERM)
+
+    def test_sigint_raises_keyboard_interrupt(self):
+        """After child exits from forwarded SIGINT, KeyboardInterrupt is raised."""
+        proc = _mock_proc(returncode=-signal.SIGTERM)
+        fake_signal, installed = _signal_tracker()
+
+        def fake_communicate():
+            handler = installed.get(signal.SIGINT)
+            if callable(handler):
+                handler(signal.SIGINT, None)
+            return (None, None)
+
+        proc.communicate.side_effect = fake_communicate
+
+        with (
+            patch("ticket_loop.main.subprocess.Popen", return_value=proc),
+            patch("ticket_loop.main.signal.signal", side_effect=fake_signal),
+            patch("ticket_loop.main.os.killpg"),
+            patch("ticket_loop.main.os.getpgid", return_value=12345),
+        ):
+            with pytest.raises(KeyboardInterrupt):
+                _run_in_process_group(["claude", "-p"])
+
+    def test_sigterm_raises_system_exit(self):
+        """After SIGTERM forwarding, SystemExit is raised."""
+        proc = _mock_proc(returncode=-signal.SIGTERM)
+        fake_signal, installed = _signal_tracker()
+
+        def fake_communicate():
+            handler = installed.get(signal.SIGTERM)
+            if callable(handler):
+                handler(signal.SIGTERM, None)
+            return (None, None)
+
+        proc.communicate.side_effect = fake_communicate
+
+        with (
+            patch("ticket_loop.main.subprocess.Popen", return_value=proc),
+            patch("ticket_loop.main.signal.signal", side_effect=fake_signal),
+            patch("ticket_loop.main.os.killpg"),
+            patch("ticket_loop.main.os.getpgid", return_value=12345),
+        ):
+            with pytest.raises(SystemExit):
+                _run_in_process_group(["claude", "-p"])
+
+    def test_sigkill_escalation_on_timeout(self):
+        """SIGKILL sent when child doesn't exit within grace period."""
+        proc = _mock_proc(returncode=-signal.SIGKILL)
+        proc.wait.side_effect = subprocess.TimeoutExpired(cmd="claude", timeout=5)
+        fake_signal, installed = _signal_tracker()
+
+        def fake_thread_class(*, target, args=(), daemon=False):
+            target(*args)
+            return MagicMock()
+
+        def fake_communicate():
+            handler = installed.get(signal.SIGINT)
+            if callable(handler):
+                handler(signal.SIGINT, None)
+            return (None, None)
+
+        proc.communicate.side_effect = fake_communicate
+
+        with (
+            patch("ticket_loop.main.subprocess.Popen", return_value=proc),
+            patch("ticket_loop.main.signal.signal", side_effect=fake_signal),
+            patch("ticket_loop.main.os.killpg") as mock_killpg,
+            patch("ticket_loop.main.os.getpgid", return_value=12345),
+            patch("ticket_loop.main.threading.Thread", side_effect=fake_thread_class),
+        ):
+            with pytest.raises(KeyboardInterrupt):
+                _run_in_process_group(["claude", "-p"])
+
+        mock_killpg.assert_any_call(12345, signal.SIGTERM)
+        mock_killpg.assert_any_call(12345, signal.SIGKILL)
+
+    def test_signal_handlers_restored_after_normal_exit(self):
+        """Original signal handlers are restored after function returns."""
+        proc = _mock_proc()
+        handler_log = []
+        original_sigint = signal.getsignal(signal.SIGINT)
+        original_sigterm = signal.getsignal(signal.SIGTERM)
+
+        def tracking_signal(signum, handler):
+            handler_log.append((signum, handler))
+            if signum == signal.SIGINT:
+                return original_sigint
+            return original_sigterm
+
+        with (
+            patch("ticket_loop.main.subprocess.Popen", return_value=proc),
+            patch("ticket_loop.main.signal.signal", side_effect=tracking_signal),
+        ):
+            _run_in_process_group(["claude", "-p"])
+
+        # 4 calls: install SIGINT, install SIGTERM, restore SIGINT, restore SIGTERM
+        assert len(handler_log) == 4
+        # Last two restore the originals saved by getsignal
+        assert handler_log[2][1] == original_sigint
+        assert handler_log[3][1] == original_sigterm
+
+    def test_signal_handlers_restored_after_exception(self):
+        """Signal handlers are restored even when check=True raises."""
+        proc = _mock_proc(returncode=1)
+        handler_log = []
+        original_sigint = signal.getsignal(signal.SIGINT)
+        original_sigterm = signal.getsignal(signal.SIGTERM)
+
+        def tracking_signal(signum, handler):
+            handler_log.append((signum, handler))
+            if signum == signal.SIGINT:
+                return original_sigint
+            return original_sigterm
+
+        with (
+            patch("ticket_loop.main.subprocess.Popen", return_value=proc),
+            patch("ticket_loop.main.signal.signal", side_effect=tracking_signal),
+        ):
+            with pytest.raises(subprocess.CalledProcessError):
+                _run_in_process_group(["claude", "-p"], check=True)
+
+        assert len(handler_log) == 4
+        assert handler_log[2][1] == original_sigint
+        assert handler_log[3][1] == original_sigterm
+
+    def test_process_lookup_error_handled_on_sigterm(self):
+        """ProcessLookupError from os.killpg is caught (child already dead)."""
+        proc = _mock_proc(returncode=0)
+        fake_signal, installed = _signal_tracker()
+
+        def fake_communicate():
+            handler = installed.get(signal.SIGINT)
+            if callable(handler):
+                handler(signal.SIGINT, None)
+            return (None, None)
+
+        proc.communicate.side_effect = fake_communicate
+
+        with (
+            patch("ticket_loop.main.subprocess.Popen", return_value=proc),
+            patch("ticket_loop.main.signal.signal", side_effect=fake_signal),
+            patch("ticket_loop.main.os.killpg", side_effect=ProcessLookupError),
+            patch("ticket_loop.main.os.getpgid", return_value=12345),
+        ):
+            # Should not raise ProcessLookupError — caught internally
+            with pytest.raises(KeyboardInterrupt):
+                _run_in_process_group(["claude", "-p"])

--- a/ticket-loop/ticket_loop/main.py
+++ b/ticket-loop/ticket_loop/main.py
@@ -153,13 +153,13 @@ def _run_with_session_retry(
         first_kwargs.setdefault("text", True)
 
     try:
-        return subprocess.run(cmd, **first_kwargs, check=True)  # noqa: S603
+        return _run_in_process_group(cmd, **first_kwargs, check=True)
     except subprocess.CalledProcessError as exc:
         stderr_text = exc.stderr or ""
         if isinstance(stderr_text, bytes):
             stderr_text = stderr_text.decode(errors="replace")
         if SESSION_CONFLICT_MSG in stderr_text:
-            return subprocess.run(  # noqa: S603
+            return _run_in_process_group(
                 _swap_session_to_resume(cmd), **kwargs, check=True
             )
         raise

--- a/ticket-loop/ticket_loop/main.py
+++ b/ticket-loop/ticket_loop/main.py
@@ -65,6 +65,71 @@ def _claude_base_cmd(*, session_id: str, skip_permissions: bool = False) -> list
     return cmd
 
 
+_SHUTDOWN_GRACE_SECONDS = 5
+
+
+def _run_in_process_group(
+    cmd: list[str], *, check: bool = False, **kwargs: Any
+) -> subprocess.CompletedProcess[str]:
+    """Run cmd in its own process group with signal forwarding.
+
+    Opens the subprocess with ``start_new_session=True`` so it gets its own
+    process group.  Installs signal handlers that forward SIGTERM to the
+    child group on SIGINT/SIGTERM, with SIGKILL escalation after a grace
+    period.
+
+    Raises:
+        subprocess.CalledProcessError: If check=True and the process exits non-zero.
+        KeyboardInterrupt: If SIGINT was received during execution.
+        SystemExit: If SIGTERM was received during execution.
+    """
+    shutdown_signal: int | None = None
+    original_sigint = signal.getsignal(signal.SIGINT)
+    original_sigterm = signal.getsignal(signal.SIGTERM)
+
+    proc = subprocess.Popen(cmd, start_new_session=True, **kwargs)  # noqa: S603
+
+    def _escalate_to_sigkill(pgid: int) -> None:
+        """Send SIGKILL after grace period if child is still alive."""
+        try:
+            proc.wait(timeout=_SHUTDOWN_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(pgid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+    def _forward_signal(signum: int, _frame: Any) -> None:
+        nonlocal shutdown_signal
+        shutdown_signal = signum
+        try:
+            pgid = os.getpgid(proc.pid)
+            os.killpg(pgid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+        threading.Thread(target=_escalate_to_sigkill, args=(pgid,), daemon=True).start()
+
+    try:
+        signal.signal(signal.SIGINT, _forward_signal)
+        signal.signal(signal.SIGTERM, _forward_signal)
+        stdout, stderr = proc.communicate()
+    finally:
+        signal.signal(signal.SIGINT, original_sigint)
+        signal.signal(signal.SIGTERM, original_sigterm)
+
+    if shutdown_signal == signal.SIGINT:
+        raise KeyboardInterrupt
+    if shutdown_signal == signal.SIGTERM:
+        raise SystemExit(1)
+
+    result = subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
+
+    if check and proc.returncode != 0:
+        raise subprocess.CalledProcessError(proc.returncode, cmd, stdout, stderr)
+
+    return result
+
+
 SESSION_CONFLICT_MSG = "is already in use"
 
 


### PR DESCRIPTION
## Summary
- Adds _run_in_process_group() function that runs subprocesses in their own process group (start_new_session=True) with signal forwarding
- On SIGINT/SIGTERM: forwards SIGTERM to the child process group, with SIGKILL escalation after a 5-second grace period
- Replaces subprocess.run with this Popen-based approach in _run_with_session_retry
- 12 new tests covering happy path, signal forwarding, SIGKILL escalation, handler restoration, and edge cases
- Existing tests updated to mock the new function

## Jira
GFD-102

## How to test
1. cd ticket-loop, then uv run poe test -- all 122 tests pass
2. cd ticket-loop, then uv run poe lint -- clean
3. Manual: run ticket-loop against a real task, press Ctrl-C, confirm claude process exits promptly with no orphans